### PR TITLE
Fixed vendor:publish tag name

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The `file_upload_size` is for validation rules, and it defines the maximum file 
 Optionally, you can publish the views using
 
 ```bash
-php artisan vendor:publish --tag="csv-views"
+php artisan vendor:publish --tag="laravel-csv-views"
 ```
 
 > Before Using this command, please take a look at this [section](#in-tall-stack-project) below.


### PR DESCRIPTION
When you use custom view namespace in spatie laravel-package-tools, you need to use your custom namespace for your published view's tag name. This PR is fix for that.